### PR TITLE
精确匹配字段名到ObjectField

### DIFF
--- a/internal/easy_scope.go
+++ b/internal/easy_scope.go
@@ -80,7 +80,7 @@ func (es *easyScope) QueryScope() *easyScope {
 	es.condition.SQLKey = es.combinedConditionSql()
 	es.condition.SQLKey = strings.ToLower(es.condition.SQLKey)
 	es.condition.SQLKey = strings.ReplaceAll(es.condition.SQLKey, "`deleted_at` is null", "")
-	extractColExp := regexp.MustCompile("`([\\w\\d_]+)`\\.`([\\w\\d_]+)`")
+	extractColExp := regexp.MustCompile("`([\\w\\d_]+)`\\.`([\\w\\d_]+)`|(([\\w\\d_]+)\\s*=\\s*\\$+)")
 	for _, field := range es.Fields() {
 		if field.IsPrimaryKey {
 			continue
@@ -94,7 +94,9 @@ func (es *easyScope) QueryScope() *easyScope {
 		// 使用正则完全匹配列名
 		if groups := extractColExp.FindAllStringSubmatch(es.condition.SQLKey, -1); len(groups) > 0 {
 			for _, group := range groups {
-				if colName := group[2]; strings.ToLower(colName) == strings.ToLower(column) {
+				group1Col_l := group[2]
+				group1Col_2 := group[4]
+				if strings.ToLower(group1Col_l) == strings.ToLower(column) || strings.ToLower(group1Col_2) == strings.ToLower(column) {
 					es.condition.ObjectField = append(es.condition.ObjectField, column)
 				}
 			}


### PR DESCRIPTION
如果简单地使用 !strings.Contains 会导致，如果表包含列名(比如tbl_content和列content)则会错误地计算为 condition.ObjectField 导致缓存失败